### PR TITLE
Corpus Similarity with tf-idf

### DIFF
--- a/nayn.dude/manticore.py
+++ b/nayn.dude/manticore.py
@@ -82,4 +82,4 @@ class CorpusSimilarity:
             self.model()
 
 news = "Katif kentinde nüfusun çoğunluğunu Şii'ler oluşturuyor. Daha önce bölgede Suudi güvenlik güçlerini hedef alan saldırdı"
-print(CorpusSimilarty().load_and_predict(news))
+print(CorpusSimilarity().load_and_predict(news))

--- a/nayn.dude/manticore.py
+++ b/nayn.dude/manticore.py
@@ -1,0 +1,85 @@
+import pandas as pd
+from nltk.corpus import stopwords
+from TurkishStemmer import TurkishStemmer
+import string
+import gensim
+from nltk.tokenize import word_tokenize
+import os
+
+class CorpusSimilarity:
+    def __init__(self):
+        pass
+
+    def load_data(self):
+        df = pd.read_csv("https://raw.githubusercontent.com/naynco/nayn.data/master/nayn.co-2016.csv")
+        df = df.dropna().reset_index(drop=True)
+        return df
+
+    def cleaning(self,doc):
+        stop_words = set(stopwords.words('turkish'))
+        stemmer = TurkishStemmer()
+        doc = doc.lower()
+        filter_punch = str.maketrans('', '', string.punctuation)
+        stripped = doc.translate(filter_punch)
+
+        clean_text = []
+        for i in stripped.split():
+            if i not in stop_words:
+                clean_text.append(stemmer.stem(i))
+
+        return ' '.join(clean_text)
+
+
+    def model(self):
+        df = self.load_data()
+        raw_documents = list(df["Content"].values)
+        print("Number of documents:", len(raw_documents))
+
+        gen_docs = []
+        for text in raw_documents:
+            word = []
+            for w in word_tokenize(self.cleaning(text)):
+                word.append(w.lower())
+
+            gen_docs.append(word)
+
+        dictionary = gensim.corpora.Dictionary(gen_docs)
+        dictionary.save_as_text("dictionary")
+
+        corpus = [dictionary.doc2bow(gen_doc) for gen_doc in gen_docs]
+        gensim.corpora.MmCorpus.serialize('corpus.mm', corpus)
+
+        tf_idf = gensim.models.TfidfModel(corpus)
+        tf_idf.save("tfidf.model")
+
+        sims = gensim.similarities.Similarity(os.getcwd(), tf_idf[corpus],
+                                              num_features=len(dictionary))
+
+        return sims
+
+
+    def load_and_predict(self,news):
+        if os.path.isfile("tfidf.model"):
+            df = self.load_data()
+            tf_idf = gensim.models.TfidfModel.load("tfidf.model")
+            dictionary = gensim.corpora.Dictionary.load_from_text("dictionary")
+            corpus = gensim.corpora.MmCorpus('corpus.mm')
+
+            sims = gensim.similarities.Similarity(os.getcwd(),tf_idf[corpus],
+                                                  num_features=len(dictionary))
+
+            query_doc = [w.lower() for w in word_tokenize(self.cleaning(news))]
+
+            query_doc_bow = dictionary.doc2bow(query_doc)
+            query_doc_tf_idf = tf_idf[query_doc_bow]
+            df_similarty = pd.DataFrame({"Similarty":sims[query_doc_tf_idf]})
+
+            result = pd.concat([df, df_similarty], axis=1, join='inner')
+            dfx = result.sort_values("Similarty",ascending=False)[:5]
+            print(dfx["Content"])
+        else:
+            print("Model train is running!")
+            self.model()
+
+news = "Katif kentinde nüfusun çoğunluğunu Şii'ler oluşturuyor. Daha önce bölgede Suudi güvenlik güçlerini hedef alan saldırdı"
+print(CorpusSimilarty().load_and_predict(news))

--- a/nayn.dude/manticore.py
+++ b/nayn.dude/manticore.py
@@ -5,10 +5,17 @@ import string
 import gensim
 from nltk.tokenize import word_tokenize
 import os
+import nltk
+
 
 class CorpusSimilarity:
     def __init__(self):
         pass
+
+    def download_nltk_models(self):
+        download_list = ["stopwords", "punkt"]
+        for download in download_list:
+            nltk.download(download)
 
     def load_data(self):
         df = pd.read_csv("https://raw.githubusercontent.com/naynco/nayn.data/master/nayn.co-2016.csv")


### PR DESCRIPTION
The common method to measure document similarity is taking the cosine similarity of TF-IDF (term frequency–inverse document frequency) scores for words in each pair of documents. 

**news** = "Katif kentinde nüfusun çoğunluğunu Şii'ler oluşturuyor. Daha önce bölgede Suudi güvenlik güçlerini hedef alan saldırdı"

**Result**
1. Suudi Arabistan'ın doğusundaki Katif kentinde ...
2. İran hükümeti ile Kürt muhalif grubu İran Kürd...
3. CIA direktörü John Brennan, Suudi Arabistan'da...
4. Suudi Arabistan öncülüğündeki koalisyon uçakla...
5.  Irak'ta hafta sonu yine can pazarı yaşandı. Ba...